### PR TITLE
Fix wrong argument type in QMessageBox.information

### DIFF
--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -230,11 +230,11 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
                     self.storage.decrypt(password)
                     break
                 except InvalidPassword as e:
-                    QMessageBox.information(None, _('Error'), str(e), _('OK'))
+                    QMessageBox.information(None, _('Error'), str(e))
                     continue
                 except BaseException as e:
                     traceback.print_exc(file=sys.stdout)
-                    QMessageBox.information(None, _('Error'), str(e), _('OK'))
+                    QMessageBox.information(None, _('Error'), str(e))
                     return
 
         path = self.storage.path

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -113,7 +113,7 @@ class HelpLabel(QLabel):
         self.font = QFont()
 
     def mouseReleaseEvent(self, x):
-        QMessageBox.information(self, 'Help', self.help_text, 'OK')
+        QMessageBox.information(self, 'Help', self.help_text)
 
     def enterEvent(self, event):
         self.font.setUnderline(True)
@@ -137,7 +137,7 @@ class HelpButton(QPushButton):
         self.clicked.connect(self.onclick)
 
     def onclick(self):
-        QMessageBox.information(self, 'Help', self.help_text, 'OK')
+        QMessageBox.information(self, 'Help', self.help_text)
 
 class Buttons(QHBoxLayout):
     def __init__(self, *buttons):
@@ -604,6 +604,6 @@ class TaskThread(QThread):
 
 if __name__ == "__main__":
     app = QApplication([])
-    t = WaitingDialog(None, 'testing ...', lambda: [time.sleep(1)], lambda x: QMessageBox.information(None, 'done', "done", _('OK')))
+    t = WaitingDialog(None, 'testing ...', lambda: [time.sleep(1)], lambda x: QMessageBox.information(None, 'done', "done"))
     t.start()
     app.exec_()


### PR DESCRIPTION
The fourth argument should be a `StandardButton`, in this case `QMessageBox.Ok`. Luckily it is already the default argument.

```
TypeError: information(QWidget, str, str, buttons: Union[QMessageBox.StandardButtons, QMessageBox.StandardButton] = QMessageBox.Ok, defaultButton: QMessageBox.StandardButton = QMessageBox.NoButton): argument 4 has unexpected type 'str'
```